### PR TITLE
fix: Use correct parameters

### DIFF
--- a/.build/PuppetPython/common.py
+++ b/.build/PuppetPython/common.py
@@ -412,7 +412,7 @@ def set_puppet_config_option(config_options, config_file_path=None, section="age
             section,
         ]
 
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, universal_newlines=True)
 
         if result.returncode != 0:
             raise Exception(
@@ -433,7 +433,7 @@ def enable_puppet_service():
 # Function to check if the user wants to change the hostname
 def check_hostname_change():
     try:
-        current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+        current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
         sys.exit(1)

--- a/.build/PuppetPython/puppet_agent.py
+++ b/.build/PuppetPython/puppet_agent.py
@@ -63,6 +63,7 @@ def parse_args():
     )
     parser.add_argument(
         "--csr-retry-interval",
+        type=int,
         help="How long to wait for the certificate to be signed",
         default=30,
     )

--- a/.build/PuppetPython/puppet_agent.py
+++ b/.build/PuppetPython/puppet_agent.py
@@ -195,7 +195,7 @@ def main():
             )
             sys.exit(1)
 
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     new_hostname = current_hostname
 
     # If the environment is set to the default of production then check if the user wants to change it

--- a/.build/PuppetPython/puppet_server.py
+++ b/.build/PuppetPython/puppet_server.py
@@ -446,7 +446,7 @@ def main():
         sys.exit(1)
 
     # Get the current hostname
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
 
     # Print out a welcome message
     print_welcome(app)

--- a/.build/Vagrantfile
+++ b/.build/Vagrantfile
@@ -47,7 +47,8 @@ Vagrant.configure('2') do |config|
   end
   # Config for a fully automated Windows Puppet agent
   config.vm.define 'auto-windows-agent', autostart: true do |awa|
-    awa.vm.box = 'gusztavvargadr/windows-server' # TODO: update this to use our box
+    awa.vm.box = 'red-gate/windows-2022-core'
+    awa.vm.box_url = 'https://vagrant.red-gate.com/red-gate/windows-2022-core'
     awa.vm.hostname = 'wa01'
     awa.vm.network :private_network, ip: '192.168.69.4'
     awa.vm.provision 'shell',
@@ -73,7 +74,8 @@ Vagrant.configure('2') do |config|
   # Config for an un-bootstrapped Windows machine that can be provisioned
   # manually, useful when you want to test the bootstrap scripts
   config.vm.define 'manual-windows-agent', autostart: false do |mwa|
-    mwa.vm.box = 'gusztavvargadr/windows-server' # TODO: update this to use our box
+    awa.vm.box = 'red-gate/windows-2022-core'
+    awa.vm.box_url = 'https://vagrant.red-gate.com/red-gate/windows-2022-core'
     mwa.vm.hostname = 'wa02'
     mwa.vm.network :private_network, ip: '192.168.69.6'
     mwa.vm.provision 'shell',

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Brownserve
+Copyright (c) 2025 Redgate
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Puppet bootstrap scripts
 
 This repository contains a set of scripts to bootstrap the installation and configuration of a Puppet server and Puppet agents.
-These scripts are designed to be used in Brownserve environments, but may well be easily adapted to other environments.
+These scripts are designed to be used in Redgate environments, but may well be easily adapted to other environments.
 
 The scripts have been tested on the following operating systems:
 

--- a/bootstrap_puppet-linux.py
+++ b/bootstrap_puppet-linux.py
@@ -519,6 +519,7 @@ def parse_args():
     )
     parser.add_argument(
         "--csr-retry-interval",
+        type=int,
         help="How long to wait for the certificate to be signed",
         default=30,
     )

--- a/bootstrap_puppet-linux.py
+++ b/bootstrap_puppet-linux.py
@@ -414,7 +414,7 @@ def set_puppet_config_option(config_options, config_file_path=None, section="age
             section,
         ]
 
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, universal_newlines=True)
 
         if result.returncode != 0:
             raise Exception(
@@ -435,7 +435,7 @@ def enable_puppet_service():
 # Function to check if the user wants to change the hostname
 def check_hostname_change():
     try:
-        current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+        current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
         sys.exit(1)
@@ -651,7 +651,7 @@ def main():
             )
             sys.exit(1)
 
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     new_hostname = current_hostname
 
     # If the environment is set to the default of production then check if the user wants to change it

--- a/bootstrap_puppet-server.py
+++ b/bootstrap_puppet-server.py
@@ -414,7 +414,7 @@ def set_puppet_config_option(config_options, config_file_path=None, section="age
             section,
         ]
 
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, universal_newlines=True)
 
         if result.returncode != 0:
             raise Exception(
@@ -435,7 +435,7 @@ def enable_puppet_service():
 # Function to check if the user wants to change the hostname
 def check_hostname_change():
     try:
-        current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+        current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
         sys.exit(1)
@@ -902,7 +902,7 @@ def main():
         sys.exit(1)
 
     # Get the current hostname
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
 
     # Print out a welcome message
     print_welcome(app)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -6,7 +6,7 @@ Below you'll find some examples of how to use the bootstrap scripts.
 
 ```bash
 # First download the script
-curl -sSL https://raw.githubusercontent.com/Brownserve-UK/puppet-bootstrap/main/bootstrap_puppet-linux.py
+curl -sSL https://raw.githubusercontent.com/red-gate/puppet-bootstrap-v2/main/bootstrap_puppet-linux.py
 
 # Then call the script and it will guide you through the process
 ./bootstrap_puppet-linux.py
@@ -19,7 +19,7 @@ It will prompt you for all information required to configure and bootstrap the a
 
 ```powershell
 # First download the script
-Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/Brownserve-UK/puppet-bootstrap/main/bootstrap_puppet-windows.ps1' -OutFile bootstrap_puppet-windows.ps1
+Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/red-gate/puppet-bootstrap-v2/main/bootstrap_puppet-windows.ps1' -OutFile bootstrap_puppet-windows.ps1
 
 # Then call the script and it will guide you through the process
 .\bootstrap_puppet-windows.ps1
@@ -32,7 +32,7 @@ It will prompt you for all information required to configure and bootstrap the a
 
 ```bash
 # First download the script
-curl -sSL https://raw.githubusercontent.com/Brownserve-UK/puppet-bootstrap/main/bootstrap_puppet-linux.py
+curl -sSL https://raw.githubusercontent.com/red-gate/puppet-bootstrap-v2/main/bootstrap_puppet-linux.py
 
 # Then call the script with all options set
 ./bootstrap_puppet-linux.py --new-hostname "linux-agent.example.com" --agent-version '7' --puppet-server "puppetserver.example.com" --environment "production" --csr-extensions '{"pp_environment":"live","pp_role":"example_node","pp_service":"example_node"}' --skip-optional-prompts
@@ -44,7 +44,7 @@ In this example, all required information has been provided as command line opti
 
 ```powershell
 # First download the script
-Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/Brownserve-UK/puppet-bootstrap/main/bootstrap_puppet-windows.ps1' -OutFile bootstrap_puppet-windows.ps1
+Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/red-gate/puppet-bootstrap-v2/main/bootstrap_puppet-windows.ps1' -OutFile bootstrap_puppet-windows.ps1
 
 # Then call the script with all options set
 .\bootstrap_puppet-windows.ps1 -NewHostname "windows-agent.example.com" -AgentVersion '7' -PuppetServer "puppetserver.example.com" -Environment "production" -CsrExtensions @{pp_environment="live";pp_role="example_node";pp_service="example_node"} -Unattended


### PR DESCRIPTION
I got caught out by copilot adding parameters that are too new for most versions of Python.
Revert to older parameters.